### PR TITLE
Improve performance of XNAT queries in study initialisation

### DIFF
--- a/arcana/__init__.py
+++ b/arcana/__init__.py
@@ -28,8 +28,8 @@ from .data import (
 from .data.file_format import FileFormat
 from .data import Fileset, Field, FilesetCollection, FieldCollection
 from .processor import (
-    LinearProcessor, MultiProcProcessor, SlurmProcessor, PROV_INCLUDE,
-    PROV_EXCLUDE)
+    LinearProcessor, MultiProcProcessor, SlurmProcessor, DEFAULT_PROV_CHECK,
+    DEFAULT_PROV_IGNORE)
 from .environment import StaticEnvironment, ModulesEnvironment
 from .repository import DirectoryRepository, XnatRepository
 # Should be set explicitly in all FSL interfaces, but this squashes the warning

--- a/arcana/__init__.py
+++ b/arcana/__init__.py
@@ -27,7 +27,9 @@ from .data import (
     AcquiredFilesetSpec, AcquiredFieldSpec)
 from .data.file_format import FileFormat
 from .data import Fileset, Field, FilesetCollection, FieldCollection
-from .processor import LinearProcessor, MultiProcProcessor, SlurmProcessor
+from .processor import (
+    LinearProcessor, MultiProcProcessor, SlurmProcessor, PROV_INCLUDE,
+    PROV_EXCLUDE)
 from .environment import StaticEnvironment, ModulesEnvironment
 from .repository import DirectoryRepository, XnatRepository
 # Should be set explicitly in all FSL interfaces, but this squashes the warning

--- a/arcana/data/file_format/base.py
+++ b/arcana/data/file_format/base.py
@@ -293,9 +293,8 @@ class FileFormat(object):
         else:
             raise ArcanaMissingDataException(
                 "Did not find single file with extension '{}' "
-                "(found '{}') in resource '{}'"
-                .format(self.extension,
-                        "', '".join(file_names), fname))
+                "(found '{}')"
+                .format(self.extension, "', '".join(file_names), fname))
         return fname
 
 

--- a/arcana/data/item.py
+++ b/arcana/data/item.py
@@ -314,6 +314,14 @@ class Fileset(BaseItem, BaseFileset):
         else:
             return self._id
 
+    @id.setter
+    def id(self, id):  # @ReservedAssignment
+        if self._id is None:
+            self._id = id
+        elif id != self._id:
+            raise ArcanaUsageError("Can't change value of ID for {} from {} "
+                                   "to {}".format(self, self._id, id))
+
     @property
     def uri(self):
         return self._uri
@@ -456,7 +464,7 @@ class Fileset(BaseItem, BaseFileset):
 
     def put(self):
         if self.repository is not None and self._path is not None:
-            self._uri = self.repository.put_fileset(self)
+            self.repository.put_fileset(self)
 
     def get_array(self):
         return self.format.get_array(self.path)

--- a/arcana/data/item.py
+++ b/arcana/data/item.py
@@ -232,11 +232,12 @@ class Fileset(BaseItem, BaseFileset):
                 return self.id < other.id
 
     def __repr__(self):
-        return ("{}(name='{}', format={}, frequency='{}', "
-                "subject_id={}, visit_id={}, from_study='{}')".format(
+        return ("{}('{}', {}, '{}', subj={}, vis={}, stdy='{}', exists={})"
+                .format(
                     type(self).__name__, self.name, self.format,
                     self.frequency, self.subject_id,
-                    self.visit_id, self.from_study))
+                    self.visit_id, self.from_study,
+                    self.exists))
 
     @property
     def fname(self):
@@ -272,6 +273,7 @@ class Fileset(BaseItem, BaseFileset):
     def path(self):
         if not self.exists:
             raise ArcanaDataNotDerivedYetError(
+                self.name,
                 "Cannot access path of {} as it hasn't been derived yet"
                 .format(self))
         if self._path is None:
@@ -320,6 +322,7 @@ class Fileset(BaseItem, BaseFileset):
     def checksums(self):
         if not self.exists:
             raise ArcanaDataNotDerivedYetError(
+                self.name,
                 "Cannot access checksums of {} as it hasn't been derived yet"
                 .format(self))
         if self._checksums is None:
@@ -580,11 +583,14 @@ class Field(BaseItem, BaseField):
             return self.name < other.name
 
     def __repr__(self):
-        return ("{}(name='{}', value={}, frequency='{}', "
-                "subject_id={}, visit_id={}, from_study='{}')".format(
-                    type(self).__name__, self.name, self._value,
+        return ("{}('{}',{} '{}', subj={}, vis={}, stdy='{}', exists={})"
+                .format(
+                    type(self).__name__, self.name,
+                    ("{}, ".format(self._value)
+                     if self._value is not None else ''),
                     self.frequency, self.subject_id,
-                    self.visit_id, self.from_study))
+                    self.visit_id, self.from_study,
+                    self.exists))
 
     def basename(self, **kwargs):  # @UnusedVariable
         return self.name
@@ -593,6 +599,7 @@ class Field(BaseItem, BaseField):
     def value(self):
         if not self.exists:
             raise ArcanaDataNotDerivedYetError(
+                self.name,
                 "Cannot access value of {} as it hasn't been "
                 "derived yet".format(repr(self)))
         if self._value is None:

--- a/arcana/data/item.py
+++ b/arcana/data/item.py
@@ -326,13 +326,19 @@ class Fileset(BaseItem, BaseFileset):
                 "Cannot access checksums of {} as it hasn't been derived yet"
                 .format(self))
         if self._checksums is None:
-            self._checksums = {}
-            for fpath in self.paths:
-                with open(fpath, 'rb') as f:
-                    self._checksums[
-                        op.relpath(fpath, self.path)] = hashlib.md5(
-                            f.read()).hexdigest()
+            if self.repository is not None:
+                self._checksums = self.repository.get_checksums(self)
+            if self._checksums is None:
+                self._checksums = self.calculate_checksums()
         return self._checksums
+
+    def calculate_checksums(self):
+        checksums = {}
+        for fpath in self.paths:
+            with open(fpath, 'rb') as f:
+                checksums[op.relpath(fpath, self.path)] = hashlib.md5(
+                    f.read()).hexdigest()
+        return checksums
 
     @classmethod
     def from_path(cls, path, frequency='per_session', format=None,  # @ReservedAssignment @IgnorePep8

--- a/arcana/data/item.py
+++ b/arcana/data/item.py
@@ -553,7 +553,18 @@ class Field(BaseItem, BaseField):
         return float(self.value)
 
     def __str__(self):
-        return str(self.value)
+        if self.array:
+            val = '[' + ','.join(self._to_str(v) for v in self.value) + ']'
+        else:
+            val = self._to_str(self.value)
+        return val
+
+    def _to_str(self, val):
+        if self.dtype is str:
+            val = '"{}"'.format(val)
+        else:
+            val = str(val)
+        return val
 
     def __lt__(self, other):
         if self.name == other.name:

--- a/arcana/data/item.py
+++ b/arcana/data/item.py
@@ -291,7 +291,7 @@ class Fileset(BaseItem, BaseFileset):
             path = op.abspath(op.realpath(path))
             self._exists = True
         self._path = path
-        self._checksums = None  # reset checksums
+        self._checksums = self.calculate_checksums()
         self.put()  # Push to repository
 
     @property
@@ -317,6 +317,14 @@ class Fileset(BaseItem, BaseFileset):
     @property
     def uri(self):
         return self._uri
+
+    @uri.setter
+    def uri(self, uri):
+        if self._uri is None:
+            self._uri = uri
+        elif uri != self._uri:
+            raise ArcanaUsageError("Can't change value of URI for {} from {} "
+                                   "to {}".format(self, self._uri, uri))
 
     @property
     def checksums(self):
@@ -448,7 +456,7 @@ class Fileset(BaseItem, BaseFileset):
 
     def put(self):
         if self.repository is not None and self._path is not None:
-            self.repository.put_fileset(self)
+            self._uri = self.repository.put_fileset(self)
 
     def get_array(self):
         return self.format.get_array(self.path)

--- a/arcana/environment/base.py
+++ b/arcana/environment/base.py
@@ -76,9 +76,7 @@ class NodeMixin(object):
     def prov(self):
         prov = {
             'interface': get_class_info(type(self.interface)),
-            'requirements': {
-                v.name: (str(v), v.local_name, v.local_version)
-                for v in self.versions},
+            'requirements': {v.name: v.prov for v in self.versions},
             'parameters': {}}
         for trait_name in self.inputs.visible_traits():
             val = getattr(self.inputs, trait_name)

--- a/arcana/environment/requirement/base.py
+++ b/arcana/environment/requirement/base.py
@@ -35,10 +35,10 @@ class Version(object):
                  local_version=None):
         self._req = requirement
         self._seq, self._prerelease, self._dev = self.parse(version)
-        self._local_version = (local_version if local_version is not None
-                               else version)
-        self._local_name = (local_name if local_name is not None
-                            else requirement.name)
+        self._local_version = (
+            local_version if local_version != str(self) else None)
+        self._local_name = (
+            local_name if local_name != requirement.name else None)
 
     @property
     def requirement(self):
@@ -66,11 +66,13 @@ class Version(object):
         The un-parsed version string. Used to cross-reference with list of
         available versions coming from an Environment
         """
-        return self._local_version
+        return (self._local_version
+                if self._local_version is not None else str(self))
 
     @property
     def local_name(self):
-        return self._local_name
+        return (self._local_name
+                if self._local_name is not None else self.requirement.name)
 
     def serialise(self):
         pass
@@ -257,6 +259,15 @@ class Version(object):
 
     def latest_within(self, *args, **kwargs):
         return self._req.latest_within_range(self, *args, **kwargs)
+
+    @property
+    def prov(self):
+        prov = {'version': str(self)}
+        if self._local_name is not None:
+            prov['local_name'] = self.local_name
+        if self._local_version is not None:
+            prov['local_version'] = self.local_version
+        return prov
 
 
 class VersionRange(object):

--- a/arcana/environment/requirement/base.py
+++ b/arcana/environment/requirement/base.py
@@ -224,11 +224,9 @@ class Version(object):
                     sequence.append(seq_part)
                 if len(sub_parts) > 1:
                     stage = sub_parts[1]
-                    pr_ver = ''.join(sub_parts[2:])
-                    try:
-                        pr_ver = int(pr_ver)
-                    except ValueError:
-                        pass
+                    pr_ver = int(sub_parts[2])
+                    if len(sub_parts) > 3:
+                        dev = ''.join(sub_parts[4:])
                     stage = stage.strip('-_').lower()
                     if not stage:  # No prerelease info, assume a dev version
                         assert dev is None

--- a/arcana/exceptions.py
+++ b/arcana/exceptions.py
@@ -46,11 +46,15 @@ class ArcanaDesignError(ArcanaError):
     pass
 
 
-class ArcanaNameError(ArcanaError):
+class NamedArcanaError(ArcanaError):
 
     def __init__(self, name, msg):
-        super(ArcanaNameError, self).__init__(msg)
+        super(NamedArcanaError, self).__init__(msg)
         self.name = name
+
+
+class ArcanaNameError(NamedArcanaError):
+    pass
 
 
 class ArcanaIndexError(ArcanaError):
@@ -60,11 +64,11 @@ class ArcanaIndexError(ArcanaError):
         self.index = index
 
 
-class ArcanaMissingDataException(ArcanaError):
+class ArcanaMissingDataException(ArcanaUsageError):
     pass
 
 
-class ArcanaDataNotDerivedYetError(ArcanaError):
+class ArcanaDataNotDerivedYetError(NamedArcanaError, ArcanaDesignError):
     pass
 
 
@@ -133,7 +137,7 @@ class ArcanaFileFormatNotRegisteredError(ArcanaError):
     pass
 
 
-class ArcanaProvenanceRecordMismatchError(ArcanaError):
+class ArcanaReprocessException(ArcanaException):
     pass
 
 

--- a/arcana/pipeline/base.py
+++ b/arcana/pipeline/base.py
@@ -48,7 +48,7 @@ class Pipeline(object):
         pipeline constructor, e.g.
 
         def my_pipeline(**name_maps):
-            pipeline = self.pipeline('my_pipeline', mods)
+            pipeline = self.new_pipeline('my_pipeline', mods)
             pipeline.add('a_node', MyInterface())
 
             ...

--- a/arcana/pipeline/base.py
+++ b/arcana/pipeline/base.py
@@ -154,7 +154,7 @@ class Pipeline(object):
             spec = self._study.spec(input)
             # Could be an input to the study or optional acquired spec
             if spec.is_spec and spec.derived:
-                prereqs[spec.pipeline_name].add(input.name)
+                prereqs[spec.pipeline_getter].add(input.name)
         return prereqs
 
     @property
@@ -165,7 +165,7 @@ class Pipeline(object):
         """
         return set(chain(
             (i for i in self.inputs if not i.derived),
-            *(self.study.get_pipeline(p, required_outputs=r).study_inputs
+            *(self.study.pipeline(p, required_outputs=r).study_inputs
               for p, r in self.prerequisites.items())))
 
     def add(self, name, interface, inputs=None, outputs=None, connect=None,

--- a/arcana/pipeline/provenance.py
+++ b/arcana/pipeline/provenance.py
@@ -1,10 +1,11 @@
+from past.builtins import basestring
 import json
 import re
 from copy import deepcopy
 from pprint import pformat
 from datetime import datetime
 from deepdiff import DeepDiff
-from arcana.exceptions import ArcanaError
+from arcana.exceptions import ArcanaError, ArcanaUsageError
 from arcana.pkg_info import install_requires
 
 
@@ -179,28 +180,54 @@ class Record(object):
         other : Provenance
             The provenance object to compare against
         include : list[list[str]] | None
-            Paths in the provenance to include in the match
+            Paths in the provenance to include in the match. If None all are
+            incluced
         exclude : list[list[str]] | None
-            Paths in the provenance to exclude from the match
+            Paths in the provenance to exclude from the match. In None all are
+            excluded
         """
-        if include is None:
-            include = ['']  # Include everything
-        if exclude is None:
-            exclude = []  # Don't exclude anything
+        if include is not None:
+            include_res = []
+            for path in include:
+                if isinstance(path, basestring):
+                    include_res.append(re.compile(
+                        r"root\['{}'\].*"
+                        .format(r"'\]\['".join(path.split('/')))))
+                elif not isinstance(path, re.Pattern):
+                    raise ArcanaUsageError(
+                        "Include paths can either be path strings or regexes, "
+                        "not '{}'".format(path))
+        if exclude is not None:
+            exclude_res = []
+            for path in exclude:
+                if isinstance(path, basestring):
+                    exclude_res.append(re.compile(
+                        r"root\['{}'\].*"
+                        .format(r"'\]\['".join(path.split('/')))))
+                elif not isinstance(path, re.Pattern):
+                    raise ArcanaUsageError(
+                        "Exclude paths can either be path strings or regexes, "
+                        "not '{}'".format(path))
         diff = DeepDiff(self._prov, other._prov, ignore_order=True)
         # Create regular expresssions for the include and exclude paths in
         # the format that deepdiff uses for nested dictionary/lists
-        include_res = [
-            re.compile(r"root\['{}'\].*".format(r"'\]\['".join(p.split('/'))))
-            for p in include]
-        exclude_res = [
-            re.compile(r"root\['{}'\].*".format(r"'\]\['".join(p.split('/'))))
-            for p in exclude]
+
+        def include_change(change):
+            if include is None:
+                included = True
+            else:
+                included = any(rx.match(change) for rx in include_res)
+            if included and exclude is not None:
+                included = not any(rx.match(change) for rx in exclude_res)
+            return included
+
         filtered_diff = {}
         for change_type, changes in diff.items():
-            filtered = [c for c in changes if (
-                any(rx.match(c) for rx in include_res) and
-                not any(rx.match(c) for rx in exclude_res))]
+            if isinstance(changes, dict):
+                filtered = dict((k, v) for k, v in changes.items()
+                                if include_change(k))
+            else:
+                filtered = [c for c in changes if include_change(c)]
             if filtered:
                 filtered_diff[change_type] = filtered
         return filtered_diff

--- a/arcana/pkg_info.py
+++ b/arcana/pkg_info.py
@@ -1,5 +1,10 @@
 
-__version__ = '0.2.8.dev1'
+__version__ = '0.2.8'
+
+__authors__ = [
+    ("Thomas G. Close", "tom.g.close@gmail.com"),
+    ("Francesco Sforazzini", "francesco.sforazzini@gmail.com"),
+    ("Phillip G. D. Ward", "phillipgdward@gmail.com")]
 
 install_requires = [
     'xnat>=0.3.9',

--- a/arcana/processor/__init__.py
+++ b/arcana/processor/__init__.py
@@ -1,4 +1,4 @@
-from .base import PROV_INCLUDE, PROV_EXCLUDE
+from .base import DEFAULT_PROV_CHECK, DEFAULT_PROV_IGNORE
 from .linear import LinearProcessor
 from .slurm import SlurmProcessor
 from .multiproc import MultiProcProcessor

--- a/arcana/processor/__init__.py
+++ b/arcana/processor/__init__.py
@@ -1,3 +1,4 @@
+from .base import PROV_INCLUDE, PROV_EXCLUDE
 from .linear import LinearProcessor
 from .slurm import SlurmProcessor
 from .multiproc import MultiProcProcessor

--- a/arcana/processor/base.py
+++ b/arcana/processor/base.py
@@ -25,6 +25,10 @@ logger = getLogger('arcana')
 
 WORKFLOW_MAX_NAME_LEN = 100
 
+PROV_INCLUDE = ['workflow', 'study/subject_ids', 'study/visit_ids', 'inputs',
+                'outputs']
+PROV_EXCLUDE = ['workflow/nodes/interface/.*/pkg_version']
+
 
 class BaseProcessor(object):
     """
@@ -65,15 +69,12 @@ class BaseProcessor(object):
 
     DEFAULT_WALL_TIME = 20
     DEFAULT_MEM_GB = 4096
-    DEFAULT_PROV_INCLUDE = ['workflow', 'study/subject_ids', 'study/visit_ids',
-                            'inputs', 'outputs']
-    DEFAULT_PROV_EXCLUDE = ['workflow/nodes/interface/.*/pkg_version']
 
     default_plugin_args = {}
 
     def __init__(self, work_dir, reprocess=False,
-                 prov_include=DEFAULT_PROV_INCLUDE,
-                 prov_exclude=DEFAULT_PROV_EXCLUDE,
+                 prov_include=PROV_INCLUDE,
+                 prov_exclude=PROV_EXCLUDE,
                  max_process_time=None,
                  clean_work_dir_between_runs=True,
                  default_wall_time=DEFAULT_WALL_TIME,

--- a/arcana/processor/base.py
+++ b/arcana/processor/base.py
@@ -281,7 +281,7 @@ class BaseProcessor(object):
             stack[pipeline.name] = pipeline, req_outputs, filt_array
             # Recursively add all prerequisites to stack
             for prq_getter, prq_req_outputs in pipeline.prerequisites.items():
-                prereq = pipeline.study.get_pipeline(prq_getter,
+                prereq = pipeline.study.pipeline(prq_getter,
                                                      prq_req_outputs)
                 try:
                     push_on_stack(prereq, filt_array, prq_req_outputs)
@@ -361,7 +361,7 @@ class BaseProcessor(object):
         prqs_to_process_array = np.zeros((len(subject_inds), len(visit_inds)),
                                          dtype=bool)
         for getter_name in pipeline.prerequisites:
-            prereq = pipeline.study.get_pipeline(getter_name)
+            prereq = pipeline.study.pipeline(getter_name)
             if prereq._to_process_array.any():
                 final_nodes.append(prereq.node('final'))
                 prqs_to_process_array |= prereq._to_process_array

--- a/arcana/processor/base.py
+++ b/arcana/processor/base.py
@@ -25,9 +25,8 @@ logger = getLogger('arcana')
 
 WORKFLOW_MAX_NAME_LEN = 100
 
-DEFAULT_PROV_CHECK = ['workflow', 'study/subject_ids', 'study/visit_ids', 'inputs',
-                'outputs']
-DEFAULT_PROV_IGNORE = ['workflow/nodes/interface/.*/pkg_version']
+DEFAULT_PROV_CHECK = ['workflow', 'inputs', 'outputs']
+DEFAULT_PROV_IGNORE = ['.*/pkg_version']
 
 
 class BaseProcessor(object):
@@ -789,9 +788,19 @@ class BaseProcessor(object):
                     # Retrieve record stored in tree node
                     record = node.record(pipeline.name, pipeline.study.name)
                     expected_record = pipeline.expected_record(node)
+
+                    # Add subjects/visits to provenance check depending on
+                    # frequency of node
+                    prov_check = copy(self.prov_check)
+                    if (self.study.SUBJECT_ID not in
+                            self.study.FREQUENCIES[node.frequency]):
+                        prov_check.append('study/subject_ids')
+                    if (self.study.VISIT_ID not in
+                            self.study.FREQUENCIES[node.frequency]):
+                        prov_check.append('study/visit_ids')
                     # Compare record with expected
                     mismatches = record.mismatches(expected_record,
-                                                   self.prov_check,
+                                                   prov_check,
                                                    self.prov_ignore)
                     if mismatches:
                         msg = ("mismatch in provenance:\n{}\n Add mismatching "

--- a/arcana/processor/base.py
+++ b/arcana/processor/base.py
@@ -25,7 +25,11 @@ logger = getLogger('arcana')
 
 WORKFLOW_MAX_NAME_LEN = 100
 
-DEFAULT_PROV_CHECK = ['workflow', 'inputs', 'outputs']
+# The default paths in the provenance JSON to check for mismatches that would
+# require the derivative to be reprocessed
+DEFAULT_PROV_CHECK = ['workflow', 'inputs', 'outputs', 'joined_ids']
+# The default paths in the provenance JSON to ignore mismatches that would
+# otherwise require the derivative to be reprocessed
 DEFAULT_PROV_IGNORE = ['.*/pkg_version']
 
 
@@ -789,18 +793,9 @@ class BaseProcessor(object):
                     record = node.record(pipeline.name, pipeline.study.name)
                     expected_record = pipeline.expected_record(node)
 
-                    # Add subjects/visits to provenance check depending on
-                    # frequency of node
-                    prov_check = copy(self.prov_check)
-                    if (self.study.SUBJECT_ID not in
-                            self.study.FREQUENCIES[node.frequency]):
-                        prov_check.append('study/subject_ids')
-                    if (self.study.VISIT_ID not in
-                            self.study.FREQUENCIES[node.frequency]):
-                        prov_check.append('study/visit_ids')
                     # Compare record with expected
                     mismatches = record.mismatches(expected_record,
-                                                   prov_check,
+                                                   self.prov_check,
                                                    self.prov_ignore)
                     if mismatches:
                         msg = ("mismatch in provenance:\n{}\n Add mismatching "

--- a/arcana/repository/base.py
+++ b/arcana/repository/base.py
@@ -138,6 +138,12 @@ class BaseRepository(with_metaclass(ABCMeta, object)):
         ----------
         fileset : Fileset
             The fileset to insert into the repository
+
+        Returns
+        -------
+        uri : str | None
+            The URI corresponding to the uploaded fileset if applicable. None
+            if not.
         """
 
     @abstractmethod

--- a/arcana/repository/base.py
+++ b/arcana/repository/base.py
@@ -138,12 +138,6 @@ class BaseRepository(with_metaclass(ABCMeta, object)):
         ----------
         fileset : Fileset
             The fileset to insert into the repository
-
-        Returns
-        -------
-        uri : str | None
-            The URI corresponding to the uploaded fileset if applicable. None
-            if not.
         """
 
     @abstractmethod

--- a/arcana/repository/base.py
+++ b/arcana/repository/base.py
@@ -78,26 +78,77 @@ class BaseRepository(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def get_fileset(self, fileset):
         """
-        If the repository is remote, cache the fileset here
+        Cache the fileset locally if required
+
+        Parameters
+        ----------
+        fileset : Fileset
+            The fileset to cache locally
+
+        Returns
+        -------
+        path : str
+            The file-system path to the cached file
         """
-        pass
 
     @abstractmethod
     def get_field(self, field):
         """
-        If the repository is remote, cache the fileset here
+        Extract the value of the field from the repository
+
+        Parameters
+        ----------
+        field : Field
+            The field to retrieve the value for
+
+        Returns
+        -------
+        value : int | float | str | list[int] | list[float] | list[str]
+            The value of the Field
         """
+
+    def get_checksums(self, fileset):  # @UnusedVariable
+        """
+        Returns the checksums for the files in the fileset that are stored in
+        the repository. If no checksums are stored in the repository then this
+        method should be left to return None and the checksums will be
+        calculated by downloading the files and taking calculating the digests
+
+        Parameters
+        ----------
+        fileset : Fileset
+            The fileset to return the checksums for
+
+        Returns
+        -------
+        checksums : dct[str, str]
+            A dictionary with keys corresponding to the relative paths of all
+            files in the fileset from the base path and values equal to the MD5
+            hex digest. The primary file in the file-set (i.e. the one that the
+            path points to) should be specified by '.'.
+        """
+        return None
 
     @abstractmethod
     def put_fileset(self, fileset):
         """
         Inserts or updates the fileset into the repository
+
+        Parameters
+        ----------
+        fileset : Fileset
+            The fileset to insert into the repository
         """
 
     @abstractmethod
     def put_field(self, field):
         """
         Inserts or updates the fields into the repository
+
+        Parameters
+        ----------
+        field : Field
+            The field to insert into the repository
         """
 
     @abstractmethod

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -463,7 +463,8 @@ class XnatRepository(BaseRepository):
                     if scan_type == self.PROV_SCAN:
                         # Download provenance JSON files and parse into
                         # records
-                        with tempfile.TemporaryDirectory() as temp_dir:
+                        temp_dir = tempfile.mkdtemp()
+                        try:
                             with tempfile.TemporaryFile() as temp_zip:
                                 self._login.download_stream(
                                     scan_uri + '/files', temp_zip,
@@ -480,6 +481,8 @@ class XnatRepository(BaseRepository):
                                                 pipeline_name, frequency,
                                                 subject_id, visit_id,
                                                 from_study, json_path))
+                        finally:
+                            shutil.rmtree(temp_dir, ignore_errors=True)
                     else:
                         try:
                             file_format = self._guess_file_format(resources,

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -211,7 +211,9 @@ class XnatRepository(BaseRepository):
         self._check_repository(field)
         with self:
             xsession = self.get_xsession(field)
-            val = parse_value(xsession.fields[field.name])
+            val = xsession.fields[field.name]
+            val = val.replace('&quot;', '"')
+            val = parse_value(val)
         return val
 
     def put_fileset(self, fileset):
@@ -391,6 +393,7 @@ class XnatRepository(BaseRepository):
                                 **kwargs))
                     # Find fields
                     for name, value in list(xsession.fields.items()):
+                        value = value.replace('&quot;', '"')
                         all_fields.append(Field(
                             name=name, value=value, repository=self,
                             frequency=frequency,

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -523,14 +523,15 @@ class XnatRepository(BaseRepository):
                 val = val.split('\\')
             return val
         with self:
-            response = self._login.get_json(
-                '/REST/services/dicomdump?src={}'
-                .format(fileset.uri[len('/data'):]))
-        hdr = {tag_parse_re.match(t['tag1']).groups():
-               convert(t['value'], t['vr'])
-               for t in response.json()['ResultSet']['Result']
-               if (tag_parse_re.match(t['tag1']) and
-                   t['vr'] in RELEVANT_DICOM_TAG_TYPES)}
+            # Replace '/data' with '/archive' in uri
+            uri = '/archive' + fileset.uri[len('/data'):]
+            response = self._login.get(
+                '/REST/services/dicomdump?src=' + uri).json()[
+                    'ResultSet']['Result']
+        hdr = {tag_parse_re.match(t['tag1']).groups(): convert(t['value'],
+                                                               t['vr'])
+               for t in response if (tag_parse_re.match(t['tag1']) and
+                                     t['vr'] in RELEVANT_DICOM_TAG_TYPES)}
         return hdr
 
     @classmethod

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -164,6 +164,7 @@ class XnatRepository(BaseRepository):
             xscan = xsession.scans[fileset.name]
             # Set URI so we can retrieve checksums if required
             fileset.uri = xscan.uri
+            fileset.id = xscan.id
             cache_path = self._cache_path(fileset)
             need_to_download = True
             if op.exists(cache_path):
@@ -240,6 +241,8 @@ class XnatRepository(BaseRepository):
             # Upload to XNAT
             xscan = self._login.classes.MrScanData(
                 type=fileset.name, parent=xsession)
+            fileset.uri = xscan.uri
+            fileset.id = xscan.id
             # Delete existing resource
             # TODO: probably should have check to see if we want to
             #       override it
@@ -253,7 +256,6 @@ class XnatRepository(BaseRepository):
             xresource = xscan.create_resource(
                 fileset.format.name.upper())
             xresource.upload(cache_path, fileset.fname)
-            return xscan.uri
 
     def put_field(self, field):
         self._check_repository(field)

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -291,11 +291,38 @@ class XnatRepository(BaseRepository):
         xresource = xprov.create_resource(record.pipeline_name)
         xresource.upload(cache_path, op.basename(cache_path))
 
+    def get_checksums(self, fileset):
+        """
+        Downloads the MD5 digests associated with the files in the file-set.
+        These are saved with the downloaded files in the cache and used to
+        check if the files have been updated on the server
+
+        Parameters
+        ----------
+        resource : xnat.ResourceCatalog
+            The xnat resource
+        file_format : FileFormat
+            The format of the fileset to get the checksums for. Used to
+            determine the primary file within the resource and change the
+            corresponding key in the checksums dictionary to '.' to match
+            the way it is generated locally by Arcana.
+        """
+        if fileset.uri is None:
+            return None
+        with self:
+            checksums = {r['Name']: r['digest']
+                         for r in self._login.get_json(fileset.uri + '/files')[
+                             'ResultSet']['Result']}
+        if not fileset.format.directory:
+            # Replace the key corresponding to the primary file with '.' to
+            # match the way that checksums are created by Arcana
+            primary = fileset.format.primary_file(checksums.keys())
+            checksums['.'] = checksums.pop(primary)
+        return checksums
+
     def find_data(self, subject_ids=None, visit_ids=None, **kwargs):
         """
-        Find all data within a repository, registering filesets, fields and
-        provenance with the found_fileset, found_field and found_provenance
-        methods, respectively
+        Find all filesets, fields and provenance records within an XNAT project
 
         Parameters
         ----------
@@ -320,87 +347,143 @@ class XnatRepository(BaseRepository):
         all_filesets = []
         all_fields = []
         all_records = []
+        # Note we prefer the use of raw REST API calls here for performance
+        # reasons over using XnatPy's data structures.
         with self:
-            xproject = self._login.projects[self.project_id]
-            # Create list of subjects
-            for xsubject in xproject.subjects.values():
-                subj_id = self.extract_subject_id(xsubject.label)
-                if subj_id == XnatRepository.SUMMARY_NAME:
-                    subj_id = None
-                elif (subject_ids is not None and subj_id not in subject_ids):
+            # Get map of internal subject IDs to subject labels in project
+            subject_xids_to_labels = {
+                s['ID']: s['label'] for s in self._login.get_json(
+                    '/data/projects/{}/subjects'.format(self.project_id))[
+                        'ResultSet']['Result']}
+            # Get list of all sessions within project
+            session_xids = [
+                s['ID'] for s in self._login.get_json(
+                    '/data/projects/{}/experiments'.format(self.project_id))[
+                        'ResultSet']['Result']]
+            for session_xid in session_xids:
+                session_json = self._login.get_json(
+                    '/data/projects/{}/experiments/{}'.format(
+                        self.project_id, session_xid))['items'][0]
+                subject_xid = session_json['data_fields']['subject_ID']
+                subject_id = subject_xids_to_labels[subject_xid]
+                session_label = session_json['data_fields']['label']
+                session_uri = ('/data/projects/{}/subjects/{}/experiments/{}'
+                               .format(self.project_id, subject_xid,
+                                       session_xid))
+                # Get field values. We do this first so we can check for the
+                # DERIVED_FROM_FIELD to determine the correct session label and
+                # study name
+                try:
+                    fields_json = next(
+                        c['items'] for c in session_json['children']
+                        if c['field'] == 'fields/field')
+                except StopIteration:
+                    field_values = {}
+                else:
+                    field_values = {
+                        js['data_fields']['name']: js['data_fields']['field']
+                        for js in fields_json}
+                # Extract study name and derived-from session
+                if self.DERIVED_FROM_FIELD in field_values:
+                    df_sess_label = field_values.pop(self.DERIVED_FROM_FIELD)
+                    from_study = session_label[len(df_sess_label) + 1:]
+                    session_label = df_sess_label
+                else:
+                    from_study = None
+                # Strip subject ID from session label if required
+                if session_label.startswith(subject_id + '_'):
+                    visit_id = session_label[len(subject_id) + 1:]
+                else:
+                    visit_id = session_label
+                # Strip project ID from subject ID if required
+                if subject_id.startswith(self.project_id + '_'):
+                    subject_id = subject_id[len(self.project_id) + 1:]
+                # Check subject is summary or not and whether it is to be
+                # filtered
+                if subject_id == XnatRepository.SUMMARY_NAME:
+                    subject_id = None
+                elif not (subject_ids is None or subject_id in subject_ids):
                     continue
-                logger.debug("Getting info for subject '{}'".format(subj_id))
-                # Store filesets and field for every session in the
-                # subject, including summary
-                # Get per_session filesets
-                for xsession in xsubject.experiments.values():
+                # Check visit is summary or not and whether it is to be
+                # filtered
+                if visit_id == XnatRepository.SUMMARY_NAME:
+                    visit_id = None
+                elif not (visit_ids is None or visit_id in visit_ids):
+                    continue
+                # Determine frequency
+                if (subject_id, visit_id) == (None, None):
+                    frequency = 'per_study'
+                elif visit_id is None:
+                    frequency = 'per_subject'
+                elif subject_id is None:
+                    frequency = 'per_visit'
+                else:
+                    frequency = 'per_session'
+                # Append fields
+                for name, value in field_values.items():
+                    value = value.replace('&quot;', '"')
+                    all_fields.append(Field(
+                        name=name, value=value, repository=self,
+                        frequency=frequency,
+                        subject_id=subject_id,
+                        visit_id=visit_id,
+                        from_study=from_study,
+                        **kwargs))
+                # Extract part of JSON relating to files
+                try:
+                    scans_json = next(
+                        c['items'] for c in session_json['children']
+                        if c['field'] == 'scans/scan')
+                except StopIteration:
+                    scans_json = []
+                for scan_json in scans_json:
+                    scan_id = scan_json['data_fields']['ID']
+                    scan_type = scan_json['data_fields']['type']
+                    scan_uri = '{}/scans/{}'.format(session_uri, scan_id)
                     try:
-                        session_label = xsession.fields[
-                            self.DERIVED_FROM_FIELD]
-                        from_study = xsession.label[len(session_label) + 1:]
-                    except KeyError:
-                        session_label = xsession.label
-                        from_study = None
-                    visit_id = self.extract_visit_id(session_label)
-                    if visit_id == XnatRepository.SUMMARY_NAME:
-                        visit_id = None
-                    elif not (visit_ids is None or visit_id in visit_ids):
-                        continue
-                    # Determine frequency
-                    if (subj_id, visit_id) == (None, None):
-                        frequency = 'per_study'
-                    elif visit_id is None:
-                        frequency = 'per_subject'
-                    elif subj_id is None:
-                        frequency = 'per_visit'
+                        resources_json = next(
+                            c['items'] for c in scan_json['children']
+                            if c['field'] == 'file')
+                    except StopIteration:
+                        resources = {}
                     else:
-                        frequency = 'per_session'
-                    # Find filesets
-                    for xscan in xsession.scans.values():
-                        if xscan.type == self.PROV_SCAN:
-                            # Download provenance JSON files and parse into
-                            # records
-                            temp_dir = tempfile.mkdtemp()
-                            try:
-                                xscan.download_dir(op.join(temp_dir, 'PROV'))
-                                resources_dir = op.join(
-                                    temp_dir, 'PROV', xsession.label, 'scans',
-                                    xscan.id + '-' + xscan.type, 'resources')
-                                for pipeline_name in os.listdir(resources_dir):
-                                    json_path = op.join(
-                                        resources_dir, pipeline_name, 'files',
-                                        pipeline_name + '.json')
-                                    all_records.append(
-                                        Record.load(pipeline_name, frequency,
-                                                    subj_id, visit_id,
-                                                    from_study, json_path))
-                            finally:
-                                shutil.rmtree(temp_dir)
-                        else:
-                            try:
-                                file_format = self._guess_file_format(xscan)
-                            except ArcanaFileFormatError as e:
-                                logger.warning(
-                                    "Ignoring '{}' as couldn't guess its file "
-                                    "format:\n{}".format(xscan.type, e))
-                            all_filesets.append(Fileset(
-                                xscan.type, format=file_format, id=xscan.id,
-                                uri=xscan.uri, repository=self,
-                                frequency=frequency, subject_id=subj_id,
-                                visit_id=visit_id, from_study=from_study,
-                                checksums=self.get_checksums(self.get_resource(
-                                    xscan, file_format), file_format),
-                                **kwargs))
-                    # Find fields
-                    for name, value in list(xsession.fields.items()):
-                        value = value.replace('&quot;', '"')
-                        all_fields.append(Field(
-                            name=name, value=value, repository=self,
-                            frequency=frequency,
-                            subject_id=subj_id,
-                            visit_id=visit_id,
-                            from_study=from_study,
-                            **kwargs))
+                        resources = {js['data_fields']['label']:
+                                     js['data_fields'].get('format', None)
+                                     for js in resources_json}
+                    # Remove auto-generated snapshots directory
+                    resources.pop('SNAPSHOTS', None)
+                    if scan_type == self.PROV_SCAN:
+                        # Download provenance JSON files and parse into
+                        # records
+                        temp_dir = tempfile.mkdtemp()
+                        try:
+                            xscan.download_dir(op.join(temp_dir, 'PROV'))
+                            resources_dir = op.join(
+                                temp_dir, 'PROV', xsession.label, 'scans',
+                                xscan.id + '-' + xscan.type, 'resources')
+                            for pipeline_name in os.listdir(resources_dir):
+                                json_path = op.join(
+                                    resources_dir, pipeline_name, 'files',
+                                    pipeline_name + '.json')
+                                all_records.append(
+                                    Record.load(pipeline_name, frequency,
+                                                subject_id, visit_id,
+                                                from_study, json_path))
+                        finally:
+                            shutil.rmtree(temp_dir)
+                    else:
+                        try:
+                            file_format = self._guess_file_format(resources,
+                                                                  scan_uri)
+                        except ArcanaFileFormatError as e:
+                            logger.warning(
+                                "Ignoring '{}' as couldn't guess its file "
+                                "format:\n{}".format(scan_type, e))
+                        all_filesets.append(Fileset(
+                            scan_type, format=file_format, id=scan_id,
+                            uri=scan_uri, repository=self, frequency=frequency,
+                            subject_id=subject_id, visit_id=visit_id,
+                            from_study=from_study, **kwargs))
                     # Find records
         return all_filesets, all_fields, all_records
 
@@ -411,9 +494,9 @@ class XnatRepository(BaseRepository):
         # TODO: need to make this generalisable via a
         #       splitting+mapping function passed to the repository
         if subject_ids is not None:
-            subject_ids = [
+            subject_ids = set(
                 ('{:03d}'.format(s)
-                 if isinstance(s, int) else s) for s in subject_ids]
+                 if isinstance(s, int) else s) for s in subject_ids)
         return subject_ids
 
     def extract_subject_id(self, xsubject_label):
@@ -440,7 +523,7 @@ class XnatRepository(BaseRepository):
                 val = val.split('\\')
             return val
         with self:
-            response = self._login.get(
+            response = self._login.get_json(
                 '/REST/services/dicomdump?src={}'
                 .format(fileset.uri[len('/data'):]))
         hdr = {tag_parse_re.match(t['tag1']).groups():
@@ -467,46 +550,14 @@ class XnatRepository(BaseRepository):
                 "', '".join(
                     r.label for r in list(xscan.resources.values()))))
 
-    @classmethod
-    def get_checksums(cls, resource, file_format):
-        """
-        Downloads the MD5 digests associated with the files in a resource.
-        These are saved with the downloaded files in the cache and used to
-        check if the files have been updated on the server
-
-        Parameters
-        ----------
-        resource : xnat.ResourceCatalog
-            The xnat resource
-        file_format : FileFormat
-            The format of the fileset to get the checksums for. Used to
-            determine the primary file within the resource and change the
-            corresponding key in the checksums dictionary to '.' to match
-            the way it is generated locally by Arcana.
-        """
-        result = resource.xnat_session.get(resource.uri + '/files')
-        if result.status_code != 200:
-            raise ArcanaError(
-                "Could not download metadata for resource {}"
-                .format(resource.id))
-        checksums = dict((r['Name'], r['digest'])
-                         for r in result.json()['ResultSet']['Result'])
-        if not file_format.directory:
-            # Replace the key corresponding to the primary file with '.' to
-            # match the way that checksums are created by Arcana
-            primary = file_format.primary_file(checksums.keys())
-            checksums['.'] = checksums.pop(primary)
-        return checksums
-
-    @classmethod
-    def download_fileset(cls, tmp_dir, xresource, xscan, fileset,
+    def download_fileset(self, tmp_dir, xresource, xscan, fileset,
                           session_label, cache_path):
         # Download resource to zip file
         zip_path = op.join(tmp_dir, 'download.zip')
         with open(zip_path, 'wb') as f:
             xresource.xnat_session.download_stream(
                 xresource.uri + '/files', f, format='zip', verbose=True)
-        checksums = cls.get_checksums(xresource, fileset.format)
+        checksums = self.get_checksums(fileset)
         # Extract downloaded zip file
         expanded_dir = op.join(tmp_dir, 'expanded')
         try:
@@ -533,8 +584,7 @@ class XnatRepository(BaseRepository):
                   **JSON_ENCODING) as f:
             json.dump(checksums, f, indent=2)
 
-    @classmethod
-    def _delayed_download(cls, tmp_dir, xresource, xscan, fileset,
+    def _delayed_download(self, tmp_dir, xresource, xscan, fileset,
                           session_label, cache_path, delay):
         logger.info("Waiting {} seconds for incomplete download of '{}' "
                     "initiated another process to finish"
@@ -551,7 +601,7 @@ class XnatRepository(BaseRepository):
                 "The download of '{}' hasn't completed yet, but it has"
                 " been updated.  Waiting another {} seconds before "
                 "checking again.".format(cache_path, delay))
-            cls._delayed_download(tmp_dir, xresource, xscan,
+            self._delayed_download(tmp_dir, xresource, xscan,
                                    fileset,
                                    session_label, cache_path, delay)
         else:
@@ -561,7 +611,7 @@ class XnatRepository(BaseRepository):
                 "restarting download".format(cache_path, delay))
             shutil.rmtree(tmp_dir)
             os.mkdir(tmp_dir)
-            cls.download_fileset(
+            self.download_fileset(
                 tmp_dir, xresource, xscan, fileset, session_label,
                 cache_path)
 
@@ -641,31 +691,29 @@ class XnatRepository(BaseRepository):
         return op.join(cache_dir, fileset.fname if name is None else name)
 
     @classmethod
-    def _guess_file_format(cls, xscan):
+    def _guess_file_format(cls, resources, uri):
         # Use a set here as in some cases there are multiple resources
         # the same format (e.g. DICOM + secondary)
-        fileset_formats = set()
-        for xresource in xscan.resources.values():
+        fileset_formats = {}
+        for label, frmt in resources.items():
+            if frmt is None:
+                frmt = label
             try:
-                fileset_formats.add(FileFormat.by_names[
-                    xresource.label.lower()])
+                fileset_formats[label] = FileFormat.by_names[frmt.lower()]
             except KeyError:
-                logger.debug("Ignoring resource '{}' in fileset {}"
-                             .format(xresource.label, xscan.type))
+                logger.debug("Ignoring resource '{}' in {}".format(frmt, uri))
         if not fileset_formats:
             raise ArcanaFileFormatError(
-                "No recognised data formats for '{}' fileset (available "
+                "No recognised data formats for '{}' (available "
                 "resources are '{}')".format(
-                    xscan.type, "', '".join(
-                        r.label for r in xscan.resources.values())))
+                    uri, "', '".join(r.label for r in resources)))
         elif len(fileset_formats) > 1:
             raise ArcanaFileFormatError(
-                "Multiple valid data-formats '{}' for '{}' fileset, please "
+                "Multiple valid data-formats '{}' for '{}', please "
                 "pass 'file_format' to 'download_fileset' method to speficy"
-                " resource to download".format(
-                    "', '".join(f.label for f in fileset_formats),
-                    xscan.type))
-        return next(iter(fileset_formats))
+                " resource to download".format("', '".join(fileset_formats),
+                                               uri))
+        return next(iter(fileset_formats.values()))
 
     def _check_repository(self, item):
         if item.repository is not self:

--- a/arcana/study/base.py
+++ b/arcana/study/base.py
@@ -509,7 +509,7 @@ class Study(object):
         "Accessor for the repository member (e.g. Daris, XNAT, MyTardis)"
         return self._repository
 
-    def pipeline(self, *args, **kwargs):
+    def new_pipeline(self, *args, **kwargs):
         """
         Creates a Pipeline object, passing the study (self) as the first
         argument

--- a/arcana/utils/testing/xnat.py
+++ b/arcana/utils/testing/xnat.py
@@ -167,12 +167,12 @@ class TestMultiSubjectOnXnatMixin(CreateXnatProjectMixin):
                     # Need to forcibly change the repository to be XNAT
                     fileset = copy(fileset)
                     fileset._repository = repo
-                    repo.put_fileset(fileset)
+                    fileset.put()
                 for field in node.fields:
                     # Need to forcibly change the repository to be XNAT
                     field = copy(field)
                     field._repository = repo
-                    repo.put_field(field)
+                    field.put()
                 for record in node.records:
                     repo.put_record(record)
 

--- a/arcana/utils/testing/xnat.py
+++ b/arcana/utils/testing/xnat.py
@@ -131,7 +131,11 @@ class TestOnXnatMixin(CreateXnatProjectMixin):
                 else:
                     resource.upload(fileset.path, fileset.fname)
             for field in self.session.fields:
-                xsession.fields[field.name] = field.value
+                if field.dtype is str:
+                    value = '"{}"'.format(field.value)
+                else:
+                    value = field.value
+                xsession.fields[field.name] = value
 
     def tearDown(self):
         # Clean up working dirs

--- a/test/misc/pkl_gen_cls.py
+++ b/test/misc/pkl_gen_cls.py
@@ -64,7 +64,7 @@ class NormalClass(with_metaclass(StudyMetaClass, Study)):
                                   'a_pipeline')]
 
     def a_pipeline(self):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'a_pipeline',
             inputs=[FilesetSpec('fileset', text_format)],
             outputs=[FilesetSpec('out_fileset', text_format)],

--- a/test/unittests/environment/test_modules.py
+++ b/test/unittests/environment/test_modules.py
@@ -64,7 +64,7 @@ class RequirementsStudy(with_metaclass(StudyMetaClass, Study)):
         FieldSpec('fours', float, 'pipeline2')]
 
     def pipeline1(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline1',
             desc=("A pipeline that tests loading of requirements"),
             name_maps=name_maps)
@@ -80,7 +80,7 @@ class RequirementsStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline2(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline2',
             desc=("A pipeline that tests loading of requirements in "
                   "map nodes"),

--- a/test/unittests/pipeline/test_prov.py
+++ b/test/unittests/pipeline/test_prov.py
@@ -256,37 +256,6 @@ class TestProvBasic(BaseTestCase):
     INPUT_DATASETS = INPUT_DATASETS
     INPUT_FIELDS = INPUT_FIELDS
 
-    def test_json_roundtrip(self):
-        """
-        Simple test whether provenance records can be written/read from a file
-        """
-        study_name = 'roundtrip_study'
-        # Test vanilla study
-        study = self.create_study(
-            TestProvStudy,
-            study_name,
-            inputs=STUDY_INPUTS)
-        # Just test to see if the pipeline works
-        self.assertEqual(next(iter(study.data('derived_field1'))).value,
-                         [3.0, 14.0, 140.0])
-        pipeline1 = study.pipeline1()
-        pipeline1.cap()
-        record = Record('pipeline1', 'per_session', self.SUBJECT, self.VISIT,
-                        study_name, pipeline1.prov)
-        tempdir = tempfile.mkdtemp()
-        try:
-            path = op.join(tempdir, 'prov1.json')
-            record.save(path)
-            reloaded = Record.load('pipeline1', 'per_session', self.SUBJECT,
-                                   self.VISIT, study_name, path)
-        finally:
-            shutil.rmtree(tempdir)
-        mismatches = record.mismatches(reloaded)
-        
-        self.assertFalse(mismatches,
-                         "Reloaded record did not match saved record:{}"
-                         .format(mismatches))
-
     def test_altered_workflow(self):
         """
         Tests whether data is regenerated if the pipeline workflows are altered

--- a/test/unittests/pipeline/test_prov.py
+++ b/test/unittests/pipeline/test_prov.py
@@ -58,7 +58,7 @@ class TestProvStudy(with_metaclass(StudyMetaClass, Study)):
         ParameterSpec('subtract', 3)]
 
     def pipeline1(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline1',
             desc="",
             references=[],
@@ -109,7 +109,7 @@ class TestProvStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline2(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline2',
             desc="",
             references=[],
@@ -158,7 +158,7 @@ class TestProvStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline3(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline3',
             desc="",
             references=[],
@@ -459,7 +459,7 @@ class TestProvDialationStudy(with_metaclass(StudyMetaClass, Study)):
         ParameterSpec('pipeline3_op', 'add')]
 
     def pipeline1(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline1',
             desc="",
             references=[],
@@ -477,7 +477,7 @@ class TestProvDialationStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline2(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline2',
             desc="",
             references=[],
@@ -496,7 +496,7 @@ class TestProvDialationStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline3(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline3',
             desc="",
             references=[],
@@ -515,7 +515,7 @@ class TestProvDialationStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline4(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline4',
             desc="",
             references=[],
@@ -550,7 +550,7 @@ class TestProvDialationStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline5(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline5',
             desc="",
             references=[],

--- a/test/unittests/pipeline/test_prov.py
+++ b/test/unittests/pipeline/test_prov.py
@@ -398,7 +398,7 @@ class TestProvBasic(BaseTestCase):
             ('derived_fileset1', 'derived_field4'))
         with open(derived_fileset1_collection.path(*self.SESSION), 'w') as f:
             f.write(str(protected_derived_fileset1_value))
-        study.clear_cache()
+        study.clear_caches()
         # Protect the output of derived_fileset1 as well and it should return
         # the protected values
         derived_fileset1_collection, derived_field4_collection = study.data(

--- a/test/unittests/pipeline/test_prov.py
+++ b/test/unittests/pipeline/test_prov.py
@@ -19,7 +19,7 @@ from arcana.data import Fileset, Field
 from arcana.repository import Tree
 from arcana.environment import BaseRequirement
 from arcana.exceptions import (
-    ArcanaProvenanceRecordMismatchError, ArcanaProtectedOutputConflictError)
+    ArcanaReprocessException, ArcanaProtectedOutputConflictError)
 
 
 class DummyRequirement(BaseRequirement):
@@ -282,6 +282,7 @@ class TestProvBasic(BaseTestCase):
         finally:
             shutil.rmtree(tempdir)
         mismatches = record.mismatches(reloaded)
+        
         self.assertFalse(mismatches,
                          "Reloaded record did not match saved record:{}"
                          .format(mismatches))
@@ -429,7 +430,7 @@ class TestProvInputChange(BaseTestCase):
             f.write('99.9')
         # Should detect that the input has changed and throw an error
         self.assertRaises(
-            ArcanaProvenanceRecordMismatchError,
+            ArcanaReprocessException,
             study.data,
             'derived_field2')
         new_study = self.create_study(

--- a/test/unittests/repository/test_base.py
+++ b/test/unittests/repository/test_base.py
@@ -40,7 +40,7 @@ class DummyStudy(with_metaclass(StudyMetaClass, Study)):
         FieldSpec('field3', str, 'dummy_pipeline')]
 
     def dummy_pipeline(self, **name_maps):
-        return self.pipeline('dummy', name_maps=name_maps)
+        return self.new_pipeline('dummy', name_maps=name_maps)
 
 
 class TestSinkAndSource(BaseTestCase):

--- a/test/unittests/repository/test_directory.py
+++ b/test/unittests/repository/test_directory.py
@@ -58,151 +58,126 @@ class TestDirectoryProjectInfo(BaseMultiSubjectTestCase):
     DATASET_CONTENTS = {'ones': 1, 'tens': 10, 'hundreds': 100,
                         'thousands': 1000}
 
-    def get_tree(self, repository, set_ids=False):
-        sessions = [
-            Session(
-                'subject1', 'visit1', filesets=[
-                    Fileset('hundreds', text_format,
-                            subject_id='subject1', visit_id='visit1',
-                            repository=repository),
-                    Fileset('ones', text_format,
-                            subject_id='subject1', visit_id='visit1',
-                            repository=repository),
-                    Fileset('tens', text_format,
-                            subject_id='subject1', visit_id='visit1',
-                            repository=repository)],
-                fields=[
-                    Field('a', value=1,
-                          subject_id='subject1', visit_id='visit1',
-                          repository=repository),
-                    Field('b', value=10,
-                          subject_id='subject1', visit_id='visit1',
-                          repository=repository),
-                    Field('d', value=42.42,
-                          subject_id='subject1', visit_id='visit1',
-                          repository=repository)]),
-            Session(
-                'subject1', 'visit2', filesets=[
-                    Fileset('ones', text_format,
-                            subject_id='subject1', visit_id='visit2',
-                            repository=repository),
-                    Fileset('tens', text_format,
-                            subject_id='subject1', visit_id='visit2',
-                            repository=repository)],
-                fields=[
-                    Field('a', value=2,
-                          subject_id='subject1', visit_id='visit2',
-                          repository=repository),
-                    Field('c', value='van',
-                          subject_id='subject1', visit_id='visit2',
-                          repository=repository)]),
-            Session(
-                'subject2', 'visit1', filesets=[
-                    Fileset('ones', text_format,
-                            subject_id='subject2', visit_id='visit1',
-                            repository=repository),
-                    Fileset('tens', text_format,
-                            subject_id='subject2', visit_id='visit1',
-                            repository=repository)],
-                fields=[]),
-            Session(
-                'subject2', 'visit2', filesets=[
-                    Fileset('ones', text_format,
-                            subject_id='subject2', visit_id='visit2',
-                            repository=repository),
-                    Fileset('tens', text_format,
-                            subject_id='subject2', visit_id='visit2',
-                            repository=repository)],
-                fields=[
-                    Field('a', value=22,
-                          subject_id='subject2', visit_id='visit2',
-                          repository=repository),
-                    Field('b', value=220,
-                          subject_id='subject2', visit_id='visit2',
-                          repository=repository),
-                    Field('c', value='buggy',
-                          subject_id='subject2', visit_id='visit2',
-                          repository=repository)])]
-        project = Tree(
-            subjects=[
-                Subject(
-                    'subject1', sessions=[s for s in sessions
-                                          if s.subject_id == 'subject1'],
-                    filesets=[
-                        Fileset('ones', text_format,
-                                frequency='per_subject',
-                                subject_id='subject1',
-                                repository=repository),
-                        Fileset('tens', text_format,
-                                frequency='per_subject',
-                                subject_id='subject1',
-                                repository=repository)],
-                    fields=[
-                        Field('e', value=4.44444,
-                              frequency='per_subject',
-                              subject_id='subject1',
-                              repository=repository)]),
-                Subject(
-                    'subject2', sessions=[s for s in sessions
-                                          if s.subject_id == 'subject2'],
-                    filesets=[
-                        Fileset('ones', text_format,
-                                frequency='per_subject',
-                                subject_id='subject2',
-                                repository=repository),
-                        Fileset('tens', text_format,
-                                frequency='per_subject',
-                                subject_id='subject2',
-                                repository=repository)],
-                    fields=[
-                        Field('e', value=3.33333,
-                              frequency='per_subject',
-                              subject_id='subject2',
-                              repository=repository)])],
-            visits=[
-                Visit(
-                    'visit1', sessions=[s for s in sessions
-                                        if s.visit_id == 'visit1'],
-                    filesets=[
-                        Fileset('ones', text_format,
-                                frequency='per_visit',
-                                visit_id='visit1',
-                                repository=repository)],
-                    fields=[
-                        Field('f', value='dog',
-                              frequency='per_visit',
-                              visit_id='visit1',
-                              repository=repository)]),
-                Visit(
-                    'visit2', sessions=[s for s in sessions
-                                        if s.visit_id == 'visit2'],
-                    filesets=[],
-                    fields=[
-                        Field('f', value='cat',
-                              frequency='per_visit',
-                              visit_id='visit2',
-                              repository=repository)])],
-            filesets=[
-                Fileset('ones', text_format,
-                        frequency='per_study',
-                        repository=repository)],
-            fields=[
-                Field('g', value=100,
-                      frequency='per_study',
-                      repository=repository)])
-        if set_ids:  # For xnat repository
-            for fileset in project.filesets:
-                fileset._id = fileset.name
-            for visit in project.visits:
-                for fileset in visit.filesets:
-                    fileset._id = fileset.name
-            for subject in project.subjects:
-                for fileset in subject.filesets:
-                    fileset._id = fileset.name
-                for session in subject.sessions:
-                    for fileset in session.filesets:
-                        fileset._id = fileset.name
-        return project
+    def get_tree(self, repo, sync_with_repo=False):
+        filesets = [
+            # Subject 2
+            Fileset('ones', text_format,
+                    frequency='per_subject',
+                    subject_id='subject2',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    frequency='per_subject',
+                    subject_id='subject2',
+                    repository=repo),
+            # subject2/visit1
+            Fileset('ones', text_format,
+                    subject_id='subject2', visit_id='visit1',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    subject_id='subject2', visit_id='visit1',
+                    repository=repo),
+            # subject2/visit2
+            Fileset('ones', text_format,
+                    subject_id='subject2', visit_id='visit2',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    subject_id='subject2', visit_id='visit2',
+                    repository=repo),
+            # Subject1
+            Fileset('ones', text_format,
+                    frequency='per_subject',
+                    subject_id='subject1',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    frequency='per_subject',
+                    subject_id='subject1',
+                    repository=repo),
+            # subject1/visit1
+            Fileset('hundreds', text_format,
+                    subject_id='subject1', visit_id='visit1',
+                    repository=repo),
+            Fileset('ones', text_format,
+                    subject_id='subject1', visit_id='visit1',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    subject_id='subject1', visit_id='visit1',
+                    repository=repo),
+            # subject1/visit2
+            Fileset('ones', text_format,
+                    subject_id='subject1', visit_id='visit2',
+                    repository=repo),
+            Fileset('tens', text_format,
+                    subject_id='subject1', visit_id='visit2',
+                    repository=repo),
+            # Visit 1
+            Fileset('ones', text_format,
+                    frequency='per_visit',
+                    visit_id='visit1',
+                    repository=repo),
+            # Study
+            Fileset('ones', text_format,
+                    frequency='per_study',
+                    repository=repo)]
+        fields = [
+            # Subject 2
+            Field('e', value=3.33333,
+                  frequency='per_subject',
+                  subject_id='subject2',
+                  repository=repo),
+            # subject2/visit2
+            Field('a', value=22,
+                  subject_id='subject2', visit_id='visit2',
+                  repository=repo),
+            Field('b', value=220,
+                  subject_id='subject2', visit_id='visit2',
+                  repository=repo),
+            Field('c', value='buggy',
+                  subject_id='subject2', visit_id='visit2',
+                  repository=repo),
+            # Subject1
+            Field('e', value=4.44444,
+                  frequency='per_subject',
+                  subject_id='subject1',
+                  repository=repo),
+            # subject1/visit1
+            Field('a', value=1,
+                  subject_id='subject1', visit_id='visit1',
+                  repository=repo),
+            Field('b', value=10,
+                  subject_id='subject1', visit_id='visit1',
+                  repository=repo),
+            Field('d', value=42.42,
+                  subject_id='subject1', visit_id='visit1',
+                  repository=repo),
+            # subject1/visit2
+            Field('a', value=2,
+                  subject_id='subject1', visit_id='visit2',
+                  repository=repo),
+            Field('c', value='van',
+                  subject_id='subject1', visit_id='visit2',
+                  repository=repo),
+            # Visit 1
+            Field('f', value='dog',
+                  frequency='per_visit',
+                  visit_id='visit1',
+                  repository=repo),
+            # Visit 2
+            Field('f', value='cat',
+                  frequency='per_visit',
+                  visit_id='visit2',
+                  repository=repo),
+            # Study
+            Field('g', value=100,
+                  frequency='per_study',
+                  repository=repo)]
+        # Set URI and IDs if necessary for repository type
+        if sync_with_repo:
+            for fileset in filesets:
+                fileset.get()
+            for field in fields:
+                field.get()
+        tree = Tree.construct(filesets, fields)
+        return tree
 
     @property
     def input_tree(self):

--- a/test/unittests/repository/xnat/test_misc.py
+++ b/test/unittests/repository/xnat/test_misc.py
@@ -18,6 +18,11 @@ sys.path.insert(0, op.join(op.dirname(__file__), '..', '..'))
 import test_data  # @UnresolvedImport @IgnorePep8
 sys.path.pop(0)
 
+# Import test_local to run TestProjectInfo on XNAT using TestOnXnat mixin
+sys.path.insert(0, op.join(op.dirname(__file__), '..', '..', 'pipeline'))
+import test_prov  # @UnresolvedImport @IgnorePep8
+sys.path.pop(0)
+
 
 dicom_format = FileFormat(name='dicom', extension=None,
                           directory=True, within_dir_exts=['.dcm'])
@@ -50,6 +55,16 @@ class TestConnectDisconnect(TestCase):
             getattr,
             repository._login,
             'classes')
+
+
+class TestProvInputChangeOnXnat(TestOnXnatMixin,
+                                test_prov.TestProvInputChange):
+
+    BASE_CLASS = test_prov.TestProvInputChange
+
+    @unittest.skipIf(*SKIP_ARGS)
+    def test_input_change(self):
+        super(TestProvInputChangeOnXnat, self).test_input_change()
 
 
 class TestDicomTagMatchAndIDOnXnat(TestOnXnatMixin,

--- a/test/unittests/repository/xnat/test_multi_subj.py
+++ b/test/unittests/repository/xnat/test_multi_subj.py
@@ -25,11 +25,6 @@ sys.path.insert(0, op.join(op.dirname(__file__), '..'))
 import test_directory  # @UnresolvedImport @IgnorePep8
 sys.path.pop(0)
 
-# Import test_local to run TestProjectInfo on XNAT using TestOnXnat mixin
-sys.path.insert(0, op.join(op.dirname(__file__), '..', '..', 'pipeline'))
-import test_prov  # @UnresolvedImport @IgnorePep8
-sys.path.pop(0)
-
 
 class TestStudy(with_metaclass(StudyMetaClass, Study)):
 
@@ -63,14 +58,6 @@ class TestProjectInfo(TestMultiSubjectOnXnatMixin,
             tree, ref_tree,
             "Generated project doesn't match reference:{}"
             .format(tree.find_mismatch(ref_tree)))
-
-
-class TestProvDialationOnXnat(TestMultiSubjectOnXnatMixin,
-                              test_prov.TestProvDialation):
-
-    @unittest.skipIf(*SKIP_ARGS)
-    def test_filter_dialation1(self):
-        super(TestProvDialationOnXnat, self).test_filter_dialation1()
 
 
 class TestXnatCache(TestMultiSubjectOnXnatMixin,

--- a/test/unittests/repository/xnat/test_multi_subj.py
+++ b/test/unittests/repository/xnat/test_multi_subj.py
@@ -53,7 +53,7 @@ class TestProjectInfo(TestMultiSubjectOnXnatMixin,
     @unittest.skipIf(*SKIP_ARGS)
     def test_project_info(self):
         tree = self.repository.tree()
-        ref_tree = self.get_tree(self.repository, set_ids=True)
+        ref_tree = self.get_tree(self.repository, sync_with_repo=True)
         self.assertEqual(
             tree, ref_tree,
             "Generated project doesn't match reference:{}"

--- a/test/unittests/repository/xnat/test_multi_subj.py
+++ b/test/unittests/repository/xnat/test_multi_subj.py
@@ -25,6 +25,11 @@ sys.path.insert(0, op.join(op.dirname(__file__), '..'))
 import test_directory  # @UnresolvedImport @IgnorePep8
 sys.path.pop(0)
 
+# Import test_local to run TestProjectInfo on XNAT using TestOnXnat mixin
+sys.path.insert(0, op.join(op.dirname(__file__), '..', '..', 'pipeline'))
+import test_prov  # @UnresolvedImport @IgnorePep8
+sys.path.pop(0)
+
 
 class TestStudy(with_metaclass(StudyMetaClass, Study)):
 
@@ -58,6 +63,14 @@ class TestProjectInfo(TestMultiSubjectOnXnatMixin,
             tree, ref_tree,
             "Generated project doesn't match reference:{}"
             .format(tree.find_mismatch(ref_tree)))
+
+
+class TestProvDialationOnXnat(TestMultiSubjectOnXnatMixin,
+                              test_prov.TestProvDialation):
+
+    @unittest.skipIf(*SKIP_ARGS)
+    def test_filter_dialation1(self):
+        super(TestProvDialationOnXnat, self).test_filter_dialation1()
 
 
 class TestXnatCache(TestMultiSubjectOnXnatMixin,

--- a/test/unittests/repository/xnat/test_source_sink.py
+++ b/test/unittests/repository/xnat/test_source_sink.py
@@ -438,7 +438,7 @@ class TestXnatSummarySourceAndSink(TestXnatSourceAndSinkBase):
             source, 'source3' + PATH_SUFFIX,
             study_sink, 'study_sink' + PATH_SUFFIX)
         workflow.run()
-        study.clear_cache()  # Refreshed cached repository tree object
+        study.clear_caches()  # Refreshed cached repository tree object
         with self._connect() as login:
             # Check subject summary directories were created properly in cache
             expected_subj_filesets = ['subject_sink']

--- a/test/unittests/repository/xnat/test_source_sink.py
+++ b/test/unittests/repository/xnat/test_source_sink.py
@@ -47,7 +47,7 @@ class DummyStudy(with_metaclass(StudyMetaClass, Study)):
         FieldSpec('field3', str, 'dummy_pipeline')]
 
     def dummy_pipeline(self, **name_maps):
-        return self.pipeline('dummy_pipeline', name_maps=name_maps)
+        return self.new_pipeline('dummy_pipeline', name_maps=name_maps)
 
 
 class TestXnatSourceAndSinkBase(TestOnXnatMixin, BaseTestCase):

--- a/test/unittests/study/test_multi.py
+++ b/test/unittests/study/test_multi.py
@@ -29,7 +29,7 @@ class StudyA(with_metaclass(StudyMetaClass, Study)):
         ParameterSpec('o3', 3.0)]
 
     def pipeline_alpha(self, **name_maps):  # @UnusedVariable
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline_alpha',
             desc="A dummy pipeline used to test MultiStudy class",
             references=[],
@@ -60,7 +60,7 @@ class StudyB(with_metaclass(StudyMetaClass, Study)):
         ParameterSpec('product_op', None, dtype=str)]  # Needs to be set to 'product' @IgnorePep8
 
     def pipeline_beta(self, **name_maps):  # @UnusedVariable
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline_beta',
             desc="A dummy pipeline used to test MultiStudy class",
             references=[],
@@ -166,7 +166,7 @@ class MultiMultiStudy(with_metaclass(MultiStudyMetaClass, MultiStudy)):
         ParameterSpec('combined_op', 'add')]
 
     def combined_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='combined',
             desc=(
                 "A dummy pipeline used to test MultiMultiStudy class"),

--- a/test/unittests/study/test_study.py
+++ b/test/unittests/study/test_study.py
@@ -60,7 +60,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         ParameterSpec('pipeline_parameter', False)]
 
     def pipeline1(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline1',
             desc="A dummy pipeline used to test 'run_pipeline' method",
             references=[],
@@ -78,7 +78,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline2(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline2',
             desc="A dummy pipeline used to test 'run_pipeline' method",
             references=[],
@@ -97,7 +97,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline3(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline3',
             desc="A dummy pipeline used to test 'run_pipeline' method",
             references=[],
@@ -110,7 +110,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline4(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline4',
             desc="A dummy pipeline used to test 'run_pipeline' method",
             references=[],
@@ -126,7 +126,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def visit_ids_access_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='visit_ids_access',
             desc=(
                 "A dummy pipeline used to test access to 'session' IDs"),
@@ -141,7 +141,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def subject_ids_access_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='subject_ids_access',
             desc=(
                 "A dummy pipeline used to test access to 'subject' IDs"),
@@ -156,7 +156,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def subject_summary_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name="subject_summary",
             desc=("Test of project summary variables"),
             references=[],
@@ -172,7 +172,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def visit_summary_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name="visit_summary",
             desc=("Test of project summary variables"),
             references=[],
@@ -188,7 +188,7 @@ class ExampleStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def study_summary_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name="study_summary",
             desc=("Test of project summary variables"),
             references=[],
@@ -330,7 +330,7 @@ class ExistingPrereqStudy(with_metaclass(StudyMetaClass, Study)):
         FilesetSpec('thousand', text_format, 'thousand_pipeline')]
 
     def pipeline_factory(self, incr, input, output, name_maps):  # @ReservedAssignment @IgnorePep8
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name=output + '_pipeline',
             desc="A dummy pipeline used to test 'partial-complete' method",
             references=[], name_maps=name_maps)
@@ -459,7 +459,7 @@ class TestInputValidationStudy(with_metaclass(StudyMetaClass, Study)):
         FilesetSpec('d', test3_format, 'identity_pipeline')]
 
     def identity_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='pipeline',
             desc="A dummy pipeline used to test study input validation",
             references=[],
@@ -551,7 +551,7 @@ class BasicTestClass(with_metaclass(StudyMetaClass, Study)):
         FilesetSpec('out_fileset', text_format, 'a_pipeline')]
 
     def a_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'a_pipeline',
             desc='a dummy pipeline',
             references=[],

--- a/test/unittests/study/test_study.py
+++ b/test/unittests/study/test_study.py
@@ -412,7 +412,7 @@ class TestExistingPrereqs(BaseMultiSubjectTestCase):
                     pipelines[fileset.name].cap()
                     record = pipelines[fileset.name].expected_record(node)
                     self.local_repository.put_record(record)
-        study.clear_cache()  # Reset repository trees
+        study.clear_caches()  # Reset repository trees
 
     def test_per_session_prereqs(self):
         # Generate all data for 'thousand' spec

--- a/test/unittests/test_converters.py
+++ b/test/unittests/test_converters.py
@@ -36,7 +36,7 @@ class ConversionStudy(with_metaclass(StudyMetaClass, Study)):
                     'conv_pipeline')]
 
     def conv_pipeline(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             name='conv_pipeline',
             name_maps=name_maps,
             desc=("A pipeline that tests out various data format "

--- a/test/unittests/test_data.py
+++ b/test/unittests/test_data.py
@@ -130,7 +130,7 @@ class TestDerivableStudy(with_metaclass(StudyMetaClass, Study)):
         SwitchSpec('branch', 'foo', ('foo', 'bar', 'wee'))]
 
     def pipeline1(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline1',
             desc="",
             references=[],
@@ -141,7 +141,7 @@ class TestDerivableStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline2(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline2',
             desc="",
             references=[],
@@ -153,7 +153,7 @@ class TestDerivableStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline3(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline3',
             desc="",
             references=[],
@@ -167,7 +167,7 @@ class TestDerivableStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline4(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline4',
             desc="",
             references=[],
@@ -178,7 +178,7 @@ class TestDerivableStudy(with_metaclass(StudyMetaClass, Study)):
         return pipeline
 
     def pipeline5(self, **name_maps):
-        pipeline = self.pipeline(
+        pipeline = self.new_pipeline(
             'pipeline5',
             desc="",
             references=[],


### PR DESCRIPTION
For large studies the time taken to query XNAT to build the repository tree using XnatPy data structures was proving very inconvenient. This PR refactors XnatRepository.find_data to use more direct REST calls (and lazily loading of checksums), which should hopefully improve performance significantly